### PR TITLE
Remove deprecation warnings when we using rails 5

### DIFF
--- a/lib/blank_image/helper.rb
+++ b/lib/blank_image/helper.rb
@@ -4,12 +4,12 @@ module BlankImage
       case format.to_sym
       when :gif
         render(
-          text: BlankImage::Image::Gif.to_s,
+          body: BlankImage::Image::Gif.to_s,
           content_type: BlankImage::Image::Gif.content_type,
         )
       when :png
         render(
-          text: BlankImage::Image::Png.to_s,
+          body: BlankImage::Image::Png.to_s,
           content_type: BlankImage::Image::Png.content_type,
         )
       else


### PR DESCRIPTION
DEPRECATION WARNING: `render :text` is deprecated because it does not
actually render a `text/plain` response. Switch to `render plain: 'plain
text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'`
to render as `text/html`, or `render body: 'raw'` to match the
deprecated behavior and render with the default Content-Type, which is
`text/html`.